### PR TITLE
fetchpatch: Sort/filter patch by filenames.

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -10,9 +10,13 @@
 fetchurl ({
   postFetch = ''
     tmpfile="$TMPDIR/${args.sha256}"
-    "${patchutils}/bin/filterdiff" --strip=${toString stripLen} --clean < "$out" > "$tmpfile"
+    "${patchutils}/bin/lsdiff" "$out" \
+      | sort -u | sed -e 's/[*?]/\\&/g' \
+      | xargs -I{} \
+        "${patchutils}/bin/filterdiff" \
+        --include={} \
+        --strip=${toString stripLen} \
+        --clean "$out" > "$tmpfile"
     mv "$tmpfile" "$out"
   '';
-  #ToDo: maybe script sorting by filename, using 'lsdiff' and 'filterdiff -i'.
 } // args)
-


### PR DESCRIPTION
This not only sorts the patch but also filters out duplicate files, currently all uses of fetchpatch lead to the same hashes so they're already sorted.
